### PR TITLE
Removing facets string methods

### DIFF
--- a/lib/sei.rb
+++ b/lib/sei.rb
@@ -4,6 +4,7 @@ require 'savon'
 require 'valuable'
 require 'gem_config'
 require 'plissken'
+require 'active_support/core_ext/string/inflections'
 
 require 'sei/connection_adapters/soap'
 require 'sei/connection_adapters/http_as_soap_proxy'

--- a/lib/sei/connection_adapters/http_as_soap_proxy.rb
+++ b/lib/sei/connection_adapters/http_as_soap_proxy.rb
@@ -2,13 +2,12 @@ module Sei
   module ConnectionAdapters
     require 'http'
     require 'singleton'
-    require 'facets/string/camelcase'
 
     class HttpAsSoapProxy
       include Singleton
 
       def call(service, message, raw_response: nil)
-        service_name = service.to_s.camelcase
+        service_name = service.to_s.camelize(:lower)
         params = { service: service_name, data: message }
         response = HTTP.post Sei.configuration.http_soap_proxy_url, json: params
         return response if raw_response

--- a/lib/sei/v3/servicos/base.rb
+++ b/lib/sei/v3/servicos/base.rb
@@ -3,9 +3,7 @@ module Sei
     module Servicos
       class Base
         def self.call(*args)
-          require 'facets/string/snakecase'
-          require 'facets/hash/deep_rekey'
-          service = name.split('::').last.snakecase.to_sym
+          service = name.split('::').last.underscore.to_sym
           message = params(*args)
           respond Sei::Connection.instance.call(
             service, message
@@ -24,7 +22,7 @@ module Sei
 
         # Simbolize all keys in the response object
         def self.parse_response(response)
-          require 'facets/hash/deep_rekey'
+          require 'facets/hash/deep_rekey' unless {}.respond_to? :deep_rekey!
           response.deep_rekey! if response.is_a? Hash
           response.each do |_key, value|
             if value.is_a? Hash

--- a/sei.gemspec
+++ b/sei.gemspec
@@ -42,4 +42,5 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'http'
   spec.add_runtime_dependency 'plissken'
   spec.add_runtime_dependency 'facets'
+  spec.add_runtime_dependency 'activesupport'
 end


### PR DESCRIPTION
Using Facets string methods were breaking Rails namespaced classes loading.